### PR TITLE
fix: Configure basePath for GitHub Pages project site

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  basePath: '/aadithyav.github.io',
+  assetPrefix: '/aadithyav.github.io/',
 };
 
 export default nextConfig;


### PR DESCRIPTION
This commit configures the `basePath` and `assetPrefix` in `next.config.mjs`. This is necessary for the portfolio to be deployed correctly as a GitHub Pages Project site (i.e., in a subdirectory).

This change ensures that all asset paths (for CSS, JS, etc.) are prefixed with the repository name, resolving the issue where the deployed site was not rendering correctly.